### PR TITLE
Dir.exists? -> Dir.exist?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rmxp_extractor (1.9)
+    rmxp_extractor (1.9.1)
       fileutils
       json
       oj

--- a/lib/rmxp_extractor/data_export.rb
+++ b/lib/rmxp_extractor/data_export.rb
@@ -1,8 +1,8 @@
 module RMXPExtractor
   def self.export(format)
     format ||= "json"
-    STDERR.puts "No Data Directory!" unless Dir.exists? "./Data"
-    exit 1 unless Dir.exists? "./Data"
+    STDERR.puts "No Data Directory!" unless Dir.exist? "./Data"
+    exit 1 unless Dir.exist? "./Data"
 
     require "json"
     require "yaml"
@@ -31,7 +31,7 @@ module RMXPExtractor
       progress_mark: "█",
       unknown_progress_animation_steps: ["==>", ">==", "=>="],
     )
-    Dir.mkdir "./Data_#{format.upcase}" unless Dir.exists? "./Data_#{format.upcase}"
+    Dir.mkdir "./Data_#{format.upcase}" unless Dir.exist? "./Data_#{format.upcase}"
     paths = Pathname.glob(("./Data/" + ("*" + ".rxdata")))
     count = paths.size
     progress.total = count

--- a/lib/rmxp_extractor/data_import.rb
+++ b/lib/rmxp_extractor/data_import.rb
@@ -1,7 +1,7 @@
 module RMXPExtractor
   def self.import(format)
-    STDERR.puts "No Data_JSON Directory!" unless Dir.exists? "./Data_#{format.upcase}"
-    exit 1 unless Dir.exists? "./Data_#{format.upcase}"
+    STDERR.puts "No Data_JSON Directory!" unless Dir.exist? "./Data_#{format.upcase}"
+    exit 1 unless Dir.exist? "./Data_#{format.upcase}"
 
     require "oj"
     require "yaml"
@@ -30,7 +30,7 @@ module RMXPExtractor
       progress_mark: "█",
       unknown_progress_animation_steps: ["==>", ">==", "=>="],
     )
-    Dir.mkdir "./Data" unless Dir.exists? "./Data"
+    Dir.mkdir "./Data" unless Dir.exist? "./Data"
     paths = Pathname.glob(("./Data_#{format.upcase}/" + ("*" + ".#{format}")))
     count = paths.size
     progress.total = count

--- a/lib/rmxp_extractor/script_handler.rb
+++ b/lib/rmxp_extractor/script_handler.rb
@@ -17,7 +17,7 @@ module RMXPExtractor
 
     if extract
       # Make sure the script directory exists
-      Dir.mkdir(scripts_dir) unless Dir.exists? scripts_dir
+      Dir.mkdir(scripts_dir) unless Dir.exist? scripts_dir
 
       # Keep track of names of scripts extracted so we can warn about duplicates
       names = Hash.new(0)

--- a/lib/rmxp_extractor/version.rb
+++ b/lib/rmxp_extractor/version.rb
@@ -1,3 +1,3 @@
 module RMXPExtractor
-  VERSION = "1.9"
+  VERSION = "1.9.1"
 end


### PR DESCRIPTION
Replaced all instances of `Dir.exists?` with `Dir.exist?` as the alias was removed in Ruby 3.2.0
Also bumped version